### PR TITLE
Disable eventOS thread

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -21,6 +21,7 @@
 #include "SDBlockDevice.h"
 #include "FATFileSystem.h"
 #include "EthernetInterface.h"
+#include "eventOS_scheduler.h"
 
 // An event queue is a very useful structure to debounce information between contexts (e.g. ISR and normal threads)
 // This is great because things such as network operations are illegal in ISR, so updating a resource in a button's fall() function is not allowed
@@ -150,6 +151,8 @@ int main(void) {
     // The timer fires on an interrupt context, but debounces it to the eventqueue, so it's safe to do network operations
     Ticker timer;
     timer.attach(eventQueue.event(&fake_button_press), 5.0);
+
+    eventQueue.call_every(1, &eventOS_scheduler_run_until_idle);
 
     // You can easily run the eventQueue in a separate thread if required
     eventQueue.dispatch_forever();

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -16,7 +16,8 @@
             "update-client.storage-address"  : "(1024*1024*64)",
             "update-client.storage-size"     : "(1024*1024*2)",
             "update-client.storage-locations": "1",
-            "mbed-trace.enable": null
+            "mbed-trace.enable": null,
+            "nanostack-hal.event-loop-dispatch-from-application": true
         },
         "K64F": {
             "sotp-section-1-address"           : "0xFE000",


### PR DESCRIPTION
[Memory hackathon] Use main thread to dispatch eventOS events around. Still registers and can subscribe / publish events around on K64F.

Not sure why we don't do this normally, there's probably a reason. If we want this we can put it in Simple Cloud Client behind the `MBED_CONF_NANOSTACK_HAL_EVENT_LOOP_DISPATCH_FROM_APPLICATION` macro.

Saves 40 bytes flash, 6144 bytes of RAM. Verified that connect + update both still work on K64F.

@bulislaw @MarceloSalazar 