### PR TITLE
disable nanostack_event_thread

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -16,7 +16,9 @@
             "update-client.storage-address"  : "(1024*1024*64)",
             "update-client.storage-size"     : "(1024*1024*2)",
             "update-client.storage-locations": "1",
-            "mbed-trace.enable": null
+            "mbed-trace.enable": null,
+            "nanostack-hal.event-loop-dispatch-from-application": "true",
+            "nanostack-hal.event-loop-use-mbed-events": "true"
         },
         "K64F": {
             "sotp-section-1-address"           : "0xFE000",


### PR DESCRIPTION
turning off nanostack_event_thread by setting following flags to true:

nanostack-hal.event-loop-dispatch-from-application
nanostack-hal.event-loop-use-mbed-events

In result:
Application is responsible of message dispatch loop
Use Mbed OS global event queue for Nanostack event loop

Related PR: https://github.com/ARMmbed/simple-mbed-cloud-client-template-restricted/pull/16
# GCC Results

# Gain
Total Static RAM memory (data + bss): 78716 - 72572 = 6144 bytes (of heap)
Total Flash memory (text + data): 395582 - 395382     =  200 bytes

## Before
Total Static RAM memory (data + bss): 78716 bytes
Total Flash memory (text + data): 395582 bytes

active threads count: 8
[ 0] id: 536949236  state: 2  priority: 24  stack_size: 4608  stack_space: 1600  name: main_thread
[ 1] id: 536889940  state: 1  priority:  1  stack_size:  512  stack_space:  432  name: idle_thread
[ 2] id: 536880012  state: 3  priority: 24  stack_size: 1200  stack_space:  608  name: tcpip_thread
[ 3] id: 536877892  state: 3  priority: 24  stack_size: 1024  stack_space:  840  name: application_unnamed_thread
[ 4] id: 536889868  state: 3  priority: 40  stack_size:  768  stack_space:  664  name: timer_thread
[ 5] id: 536888216  state: 3  priority: 24  stack_size:  512  stack_space:  312  name: Kinetis_EMAC_thread
[ 6] id: 536887584  state: 3  priority: 24  stack_size: 6144  stack_space: 2368  name: nanostack_event_thread
[ 7] id: 536876312  state: 3  priority: 40  stack_size: 1024  stack_space:  728  name: application_unnamed_thread


## After
Total Static RAM memory (data + bss): 72572 bytes
Total Flash memory (text + data): 395382 bytes

active threads count: 7
[ 0] id: 536943092  state: 2  priority: 24  stack_size: 4608  stack_space: 1600  name: main_thread
[ 1] id: 536883732  state: 1  priority:  1  stack_size:  512  stack_space:  416  name: idle_thread
[ 2] id: 536877892  state: 3  priority: 24  stack_size: 1024  stack_space:  840  name: application_unnamed_thread
[ 3] id: 536880012  state: 3  priority: 24  stack_size: 1200  stack_space:  608  name: tcpip_thread
[ 4] id: 536883660  state: 3  priority: 40  stack_size:  768  stack_space:  664  name: timer_thread
[ 5] id: 536882004  state: 3  priority: 24  stack_size:  512  stack_space:  312  name: Kinetis_EMAC_thread
[ 6] id: 536876312  state: 3  priority: 40  stack_size: 1024  stack_space:  728  name: application_unnamed_thread