### PR TITLE
Add default wifi config

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -16,7 +16,10 @@
             "update-client.storage-address"  : "(1024*1024*64)",
             "update-client.storage-size"     : "(1024*1024*2)",
             "update-client.storage-locations": "1",
-            "mbed-trace.enable": null
+            "mbed-trace.enable": null,
+            "nsapi.default-wifi-security"       : "WPA_WPA2",
+            "nsapi.default-wifi-ssid"           : "\"SSID\"",
+            "nsapi.default-wifi-password"       : "\"Password\""
         },
         "K64F": {
             "target.features_add"              : ["BOOTLOADER"],


### PR DESCRIPTION
This enables an application to use the WiFi credentials and the default network interface.

Requires this: https://github.com/ARMmbed/simple-mbed-cloud-client/pull/31

@dhwalters423 