### PR TITLE
Dissable main when testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,7 +516,7 @@ Follow these steps to generate a manifest, compile and perform a firmware update
 5. Update the firmware of the device through Mbed CLI:
    
     ```
-    mbed dm update device -D <device ID>
+    mbed dm update device -D <device ID> -t <target> -m <toolchain>
     ```
     
     Inspect the logs on the device to see the update progress. It should look similar to:

--- a/main.cpp
+++ b/main.cpp
@@ -15,6 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ----------------------------------------------------------------------------
+#ifndef MBED_TEST_MODE
 
 #include "mbed.h"
 #include "simple-mbed-cloud-client.h"
@@ -156,3 +157,4 @@ int main(void) {
     // You can easily run the eventQueue in a separate thread if required
     eventQueue.dispatch_forever();
 }
+#endif


### PR DESCRIPTION
This enables tests to run without having to remove/rename main.