### PR TITLE
Fix config for NUCLEO F429

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -1,23 +1,13 @@
 {
-    "config": {
-        "format-storage-layer-on-error": {
-            "help": "Whether to format the storage layer when it cannot be read - always disable for production devices!",
-            "value": 1
-        },
-        "developer-mode": {
-            "help": "Enable Developer mode to skip Factory enrollment",
-            "value": 1
-        },
-        "main-stack-size": {
-            "value": 6000
-        }
-    },
     "macros": [
         "ARM_UC_USE_PAL_BLOCKDEVICE=1",
         "MBED_CLOUD_CLIENT_UPDATE_STORAGE=ARM_UCP_FLASHIAP_BLOCKDEVICE",
         "MBED_CLIENT_USER_CONFIG_FILE=\"mbed_cloud_client_user_config.h\"",
         "MBED_CLOUD_CLIENT_USER_CONFIG_FILE=\"mbed_cloud_client_user_config.h\"",
-        "PAL_FS_MOUNT_POINT_PRIMARY=\"/fs\""
+        "PAL_USER_DEFINED_CONFIGURATION=\"sotp_fs_config_MbedOS.h\"",
+        "PAL_FS_MOUNT_POINT_PRIMARY=\"/fs\"",
+        "MBEDTLS_USER_CONFIG_FILE=\"mbedTLSConfig_mbedOS.h\"",
+        "PAL_DTLS_PEER_MIN_TIMEOUT=5000"
     ],
     "target_overrides": {
         "*": {
@@ -35,13 +25,6 @@
             "nsapi.default-wifi-security"       : "WPA_WPA2",
             "nsapi.default-wifi-ssid"           : "\"SSID\"",
             "nsapi.default-wifi-password"       : "\"Password\""
-        },
-        "STM_EMAC": {
-            "lwip.pbuf-pool-size"               : 16,
-            "lwip.mem-size"                     : 12500,
-            "client_app.pal_number_of_partition": 1,
-            "client_app.partition_mode"         : 1,
-            "client_app.auto_partition"         : 1
         },
         "K64F": {
             "target.network-default-interface-type" : "ETHERNET",
@@ -77,6 +60,44 @@
             "client_app.sotp-section-1-size"        : "(128*1024)",
             "client_app.sotp-section-2-address"     : "(0x081E0000)",
             "client_app.sotp-section-2-size"        : "(128*1024)"
+        }
+    },
+    "config": {
+        "format-storage-layer-on-error": {
+            "help": "Whether to format the storage layer when it cannot be read - always disable for production devices!",
+            "value": 1
+        },
+        "developer-mode": {
+            "help": "Enable Developer mode to skip Factory enrollment",
+            "value": 1
+        },
+        "main-stack-size": {
+            "value": 6000
+        },
+        "sotp-section-1-address": {
+            "help": "Flash sector address for SOTP sector 1",
+            "macro_name": "PAL_INTERNAL_FLASH_SECTION_1_ADDRESS",
+            "value": null
+        },
+        "sotp-section-1-size": {
+            "help": "Flash sector size for SOTP sector 1",
+            "macro_name": "PAL_INTERNAL_FLASH_SECTION_1_SIZE",
+            "value": null
+        },
+        "sotp-section-2-address": {
+            "help": "Flash sector address for SOTP sector 2",
+            "macro_name": "PAL_INTERNAL_FLASH_SECTION_2_ADDRESS",
+            "value": null
+        },
+        "sotp-section-2-size": {
+            "help": "Flash sector size for SOTP sector 2",
+            "macro_name": "PAL_INTERNAL_FLASH_SECTION_2_SIZE",
+            "value": null
+        },
+        "sotp-num-sections": {
+            "help": "Number of SOTP sections",
+            "macro_name": "PAL_INT_FLASH_NUM_SECTIONS",
+            "value": null
         }
     }
 }


### PR DESCRIPTION
@micgur01 identified build issue with F429 when trying to build the template.

The F429 was already working (see [tests](https://github.com/ARMmbed/smcc-tests)) but the config was not populated to this template.

