### PR TITLE
Nuvoton: Fix button pressed state to 0

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -357,7 +357,8 @@
             "target.features_add"                       : ["BOOTLOADER"],
             "target.bootloader_img"                     : "bootloader/mbed-bootloader-NUMAKER_PFM_NUC472.bin",
             "target.header_offset"                      : "0x10000",
-            "target.app_offset"                         : "0x10400"
+            "target.app_offset"                         : "0x10400",
+            "button-pressed-state"                      : 0
         },
         "NUMAKER_PFM_M487": {
             "target.components_add"                     : ["NUSD"],
@@ -377,7 +378,8 @@
             "target.features_add"                       : ["BOOTLOADER"],
             "target.bootloader_img"                     : "bootloader/mbed-bootloader-NUMAKER_PFM_M487.bin",
             "target.header_offset"                      : "0x10000",
-            "target.app_offset"                         : "0x10400"
+            "target.app_offset"                         : "0x10400",
+            "button-pressed-state"                      : 0
         },
         "NUMAKER_IOT_M487": {
             "target.components_add"                     : ["NUSD"],
@@ -400,7 +402,8 @@
             "target.features_add"                       : ["BOOTLOADER"],
             "target.bootloader_img"                     : "bootloader/mbed-bootloader-NUMAKER_IOT_M487.bin",
             "target.header_offset"                      : "0x10000",
-            "target.app_offset"                         : "0x10400"
+            "target.app_offset"                         : "0x10400",
+            "button-pressed-state"                      : 0
         },
         "SDT64B": {
             "target.components_add"                     : ["SD"],


### PR DESCRIPTION
This PR fixes button pressed state to 0 for Nuvoton targets:

- NUMAKER_PFM_NUC472
- NUMAKER_PFM_M487
- NUMAKER_IOT_M487