### PR TITLE
Update to PDMC 3.0.0

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -5,6 +5,7 @@
             "platform.stdio-baud-rate"                  : 115200,
             "platform.stdio-convert-newlines"           : true,
             "mbed-trace.enable"                         : null,
+            "mbed-cloud-client.external-sst-support"    : null,
             "nsapi.default-wifi-security"               : "WPA_WPA2",
             "nsapi.default-wifi-ssid"                   : "\"SSID\"",
             "nsapi.default-wifi-password"               : "\"Password\""

--- a/simple-mbed-cloud-client.lib
+++ b/simple-mbed-cloud-client.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/simple-mbed-cloud-client/#2ad31604eb91b1facc11b2f9d1ba4e54a80d1384
+https://github.com/ARMmbed/simple-mbed-cloud-client/#6b15c0d7a084d4bfd7bb10cdd2d1c993bced31bb


### PR DESCRIPTION
Note that this requires the application config to define "mbed-cloud-client.external-sst-support" : null to re-enable the nvstore SOTP support.

Test results based on https://github.com/ARMmbed/pelion-enablement/pull/67

Test results from setup 1:
```
+---------------------+-------------------------------------------------+--------+--------+
| target              | test suite                                      | result |   time |
+---------------------+-------------------------------------------------+--------+--------+
| DISCO_F413ZH        | simple-mbed-cloud-client-tests-dev_mgmt-update  | OK     | 170.43 |
| DISCO_F413ZH        | simple-mbed-cloud-client-tests-dev_mgmt-connect | OK     |  84.01 |
| DISCO_F746NG        | simple-mbed-cloud-client-tests-dev_mgmt-update  | OK     | 187.54 |
| DISCO_F746NG        | simple-mbed-cloud-client-tests-dev_mgmt-connect | OK     | 116.55 |
| DISCO_F769NI        | simple-mbed-cloud-client-tests-dev_mgmt-update  | OK     | 154.45 |
| DISCO_F769NI        | simple-mbed-cloud-client-tests-dev_mgmt-connect | OK     |  138.7 |
| DISCO_L475VG_IOT01A | simple-mbed-cloud-client-tests-dev_mgmt-update  | OK     | 168.11 |
| DISCO_L475VG_IOT01A | simple-mbed-cloud-client-tests-dev_mgmt-connect | OK     |  88.87 |
| EFM32GG11_STK3701   | simple-mbed-cloud-client-tests-dev_mgmt-update  | OK     | 139.92 |
| EFM32GG11_STK3701   | simple-mbed-cloud-client-tests-dev_mgmt-connect | OK     |  73.69 |
| GR_LYCHEE           | simple-mbed-cloud-client-tests-dev_mgmt-update  | OK     | 251.82 |
| GR_LYCHEE           | simple-mbed-cloud-client-tests-dev_mgmt-connect | OK     |  85.57 |
| K64F                | simple-mbed-cloud-client-tests-dev_mgmt-update  | OK     | 169.62 |
| K64F                | simple-mbed-cloud-client-tests-dev_mgmt-connect | OK     |  87.88 |
| K66F                | simple-mbed-cloud-client-tests-dev_mgmt-update  | OK     | 157.34 |
| K66F                | simple-mbed-cloud-client-tests-dev_mgmt-connect | OK     |   81.8 |
| NUCLEO_F207ZG       | simple-mbed-cloud-client-tests-dev_mgmt-update  | OK     | 164.92 |
| NUCLEO_F207ZG       | simple-mbed-cloud-client-tests-dev_mgmt-connect | OK     |  83.15 |
| NUCLEO_F429ZI       | simple-mbed-cloud-client-tests-dev_mgmt-update  | OK     | 169.51 |
| NUCLEO_F429ZI       | simple-mbed-cloud-client-tests-dev_mgmt-connect | OK     |   72.4 |
| NUCLEO_F746ZG       | simple-mbed-cloud-client-tests-dev_mgmt-update  | OK     | 142.78 |
| NUCLEO_F746ZG       | simple-mbed-cloud-client-tests-dev_mgmt-connect | OK     |  65.52 |
| NUCLEO_F767ZI       | simple-mbed-cloud-client-tests-dev_mgmt-update  | OK     |  141.0 |
| NUCLEO_F767ZI       | simple-mbed-cloud-client-tests-dev_mgmt-connect | OK     |  64.31 |
| NUMAKER_IOT_M487    | simple-mbed-cloud-client-tests-dev_mgmt-update  | OK     | 161.21 |
| NUMAKER_IOT_M487    | simple-mbed-cloud-client-tests-dev_mgmt-connect | OK     |  64.68 |
| NUMAKER_PFM_M487    | simple-mbed-cloud-client-tests-dev_mgmt-update  | OK     | 129.53 |
| NUMAKER_PFM_M487    | simple-mbed-cloud-client-tests-dev_mgmt-connect | OK     |  63.09 |
| NUMAKER_PFM_NUC472  | simple-mbed-cloud-client-tests-dev_mgmt-update  | OK     | 210.37 |
| NUMAKER_PFM_NUC472  | simple-mbed-cloud-client-tests-dev_mgmt-connect | OK     | 141.83 |
| RZ_A1H              | simple-mbed-cloud-client-tests-dev_mgmt-update  | OK     | 211.82 |
| RZ_A1H              | simple-mbed-cloud-client-tests-dev_mgmt-connect | OK     |   79.8 |
| UBLOX_C030_U201     | simple-mbed-cloud-client-tests-dev_mgmt-update  | OK     | 991.05 |
| UBLOX_C030_U201     | simple-mbed-cloud-client-tests-dev_mgmt-connect | OK     | 145.37 |
| UBLOX_EVK_ODIN_W2   | simple-mbed-cloud-client-tests-dev_mgmt-update  | OK     | 472.41 |
| UBLOX_EVK_ODIN_W2   | simple-mbed-cloud-client-tests-dev_mgmt-connect | OK     | 167.13 |
+---------------------+-------------------------------------------------+--------+--------+
```


Test results from setup 2:
```
+---------------------+-------------------------------------------------+--------+--------+
| target              | test suite                                      | result |   time |
+---------------------+-------------------------------------------------+--------+--------+
| DISCO_F469NI        | simple-mbed-cloud-client-tests-dev_mgmt-update  | OK     | 201.29 |
| DISCO_F469NI        | simple-mbed-cloud-client-tests-dev_mgmt-connect | OK     |  89.64 |
| DISCO_L496AG        | simple-mbed-cloud-client-tests-dev_mgmt-update  | OK     | 219.15 |
| DISCO_L496AG        | simple-mbed-cloud-client-tests-dev_mgmt-connect | OK     |  99.89 |
| MTB_ADV_WISE_1530   | simple-mbed-cloud-client-tests-dev_mgmt-update  | OK     | 270.88 |
| MTB_ADV_WISE_1530   | simple-mbed-cloud-client-tests-dev_mgmt-connect | OK     | 107.64 |
| MTB_MXCHIP_EMW3166  | simple-mbed-cloud-client-tests-dev_mgmt-update  | OK     | 230.37 |
| MTB_MXCHIP_EMW3166  | simple-mbed-cloud-client-tests-dev_mgmt-connect | OK     |  98.46 |
| MTB_USI_WM_BN_BM_22 | simple-mbed-cloud-client-tests-dev_mgmt-update  | OK     | 271.21 |
| MTB_USI_WM_BN_BM_22 | simple-mbed-cloud-client-tests-dev_mgmt-connect | OK     | 108.82 |
| NUCLEO_F412ZG       | simple-mbed-cloud-client-tests-dev_mgmt-update  | OK     |  230.9 |
| NUCLEO_F412ZG       | simple-mbed-cloud-client-tests-dev_mgmt-connect | OK     | 108.22 |
| NUCLEO_L476RG       | simple-mbed-cloud-client-tests-dev_mgmt-update  | OK     | 238.17 |
| NUCLEO_L476RG       | simple-mbed-cloud-client-tests-dev_mgmt-connect | OK     | 203.71 |
| NUCLEO_L496ZG       | simple-mbed-cloud-client-tests-dev_mgmt-update  | OK     | 241.95 |
| NUCLEO_L496ZG       | simple-mbed-cloud-client-tests-dev_mgmt-connect | OK     | 104.82 |
| NUCLEO_L4R5ZI       | simple-mbed-cloud-client-tests-dev_mgmt-update  | OK     | 258.26 |
| NUCLEO_L4R5ZI       | simple-mbed-cloud-client-tests-dev_mgmt-connect | OK     | 122.46 |
| SDT64B              | simple-mbed-cloud-client-tests-dev_mgmt-update  | OK     |  190.2 |
| SDT64B              | simple-mbed-cloud-client-tests-dev_mgmt-connect | OK     |  88.86 |
| TB_SENSE_12         | simple-mbed-cloud-client-tests-dev_mgmt-update  | OK     | 579.84 |
| TB_SENSE_12         | simple-mbed-cloud-client-tests-dev_mgmt-connect | OK     | 117.97 |
+---------------------+-------------------------------------------------+--------+--------+
```